### PR TITLE
Expose callHackageDirect

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,4 +39,5 @@ in {
   inherit reflex-platform-func rp pkgs;
   inherit (rp) hackGet ghc8_6 ghcjs8_6;
   inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreSource;
+  callHackageDirect = rp.nixpkgs.haskellPackages.callHackageDirect;
 }


### PR DESCRIPTION
This makes it easy for downstream packages to use `callHackageDirect` to override kpkgs pins for local testing.